### PR TITLE
Formatting and multi FBX in same folder fail bug fix

### DIFF
--- a/DemoProject/Assets/Hash's_Things/EditDistributor/Editor/CommunFonctions.cs
+++ b/DemoProject/Assets/Hash's_Things/EditDistributor/Editor/CommunFonctions.cs
@@ -74,7 +74,7 @@ namespace EditDistributor
 
         public static void PrintMissingFileError(string PathToFile)
         {
-            UnityEngine.Debug.Log("please make sure you have " + Path.GetFileName(PathToFile) + " in: " + PathToFile);
+            UnityEngine.Debug.Log("Please make sure you have " + Path.GetFileName(PathToFile) + " in: " + PathToFile);
         }
 
 

--- a/DemoProject/Assets/Hash's_Things/EditDistributor/Editor/EditDistributorBuilder.cs
+++ b/DemoProject/Assets/Hash's_Things/EditDistributor/Editor/EditDistributorBuilder.cs
@@ -131,7 +131,7 @@ namespace EditDistributor {
                             }
                             else
                             {
-                                outputDirectory = Path.Combine(CommunFonctions.GoUpNDirs(CustomfbxPath, 2), "patcher", "data", "DiffFiles");
+                                outputDirectory = Path.Combine(CommunFonctions.GoUpNDirs(CustomfbxPath, 2), "Patcher", "Data", "DiffFiles");
                                 if (NameOverwriteTickBox)
                                 {
                                     if (!string.IsNullOrEmpty(DistributionNameOverwriteText))
@@ -142,7 +142,7 @@ namespace EditDistributor {
                                 }
                                 else
                                 {
-                                    patcherFolder = Path.Combine(CommunFonctions.GoUpNDirs(CustomfbxPath, 2), "patcher");
+                                    patcherFolder = Path.Combine(CommunFonctions.GoUpNDirs(CustomfbxPath, 2), "Patcher");
                                     PatcherScriptDestDir = Path.Combine(CommunFonctions.GoUpNDirs(outputDirectory, 2), "Editor", Path.GetFileNameWithoutExtension(CustomfbxPath).Replace(" ", "_") + "_Patcher.cs");
                                 }
                             }
@@ -174,9 +174,9 @@ namespace EditDistributor {
                     UserEditorWindowName = EditorGUILayout.TextField(new GUIContent("Your Name: ", "Will be used to organize your patchers in the menu bar"), UserEditorWindowName);
                     if (NameOverwriteTickBox)
                     {
-                        if (! string.IsNullOrEmpty(DistributionNameOverwriteText)) EditorWindowPath = "Tools/" + UserEditorWindowName + "/" + DistributionNameOverwriteText.Replace(" ", "_") + "_Patcher";
+                        if (! string.IsNullOrEmpty(DistributionNameOverwriteText)) EditorWindowPath = "Tools/" + UserEditorWindowName + "/" + DistributionNameOverwriteText + " Patch";
                     }
-                    else EditorWindowPath = "Tools/" + UserEditorWindowName + "/" + Path.GetFileNameWithoutExtension(OGfbxPath) + "Patcher";
+                    else EditorWindowPath = "Tools/" + UserEditorWindowName + "/" + Path.GetFileNameWithoutExtension(OGfbxPath) + " Patch";
                     if (string.IsNullOrEmpty(UserEditorWindowName))
                     {
 
@@ -395,8 +395,10 @@ namespace EditDistributor {
 
         private void BuildPatcher()
         {
-        
-            Directory.CreateDirectory(outputDirectory);
+            //Check if output directory already exists
+            if (!Directory.Exists(outputDirectory)){
+                Directory.CreateDirectory(outputDirectory);
+            }
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)){
                 hdiffz = Path.Combine(Environment.CurrentDirectory, "Assets", "Hash's_Things", "EditDistributor", "hdiff", "hdiffz", "Windows", "hdiffz.exe");
@@ -444,9 +446,12 @@ namespace EditDistributor {
             }
             else PatcherScriptDestDir = Path.Combine(CommunFonctions.GoUpNDirs(outputDirectory, 2), "Editor", Path.GetFileNameWithoutExtension(CustomfbxPath).Replace(" ", "_") + "_Patcher.cs");
 
+            //Check if patcher script destination director already exists
+            if (!Directory.Exists(CommunFonctions.GoUpNDirs(PatcherScriptDestDir, 1))){
+                Directory.CreateDirectory(CommunFonctions.GoUpNDirs(PatcherScriptDestDir, 1));
+                CommunFonctions.CopyFolder(hdiffzFolder, hpatchzDestDir);
+            }
 
-            Directory.CreateDirectory(CommunFonctions.GoUpNDirs(PatcherScriptDestDir, 1));
-            CommunFonctions.CopyFolder(hdiffzFolder, hpatchzDestDir);
             CommunFonctions.CheckAndCopyFileIfExists(PatcherTemplateScript, PatcherScriptDestDir);
 
 
@@ -459,7 +464,7 @@ namespace EditDistributor {
             UnityEngine.Debug.Log(EditorWindowPath);
             CommunFonctions.ReplaceStringsInFile(PatcherScriptDestDir, originalStrings, remplacementStrings);
 
-            UnityEngine.Debug.Log("patcher created yippie :D");
+            UnityEngine.Debug.Log("Patcher created");
             AssetDatabase.Refresh();
         }
 
@@ -469,7 +474,7 @@ namespace EditDistributor {
 
         private void AddDebugInfo()
         {
-            string outputDirectory = Path.Combine(CommunFonctions.GoUpNDirs(CustomfbxPath, 2), "patcher", "data", "DiffFiles");
+            string outputDirectory = Path.Combine(CommunFonctions.GoUpNDirs(CustomfbxPath, 2), "Patcher", "Data", "DiffFiles");
             //some debug things that helped tracing back issues
             GUILayout.Label("outputDirectory: " + outputDirectory);
             GUILayout.Label("hdiff: " + Path.Combine(Environment.CurrentDirectory, "Assets", "Hash's_Things", "EditDistributor", "pythonscripts", "hdiff", "hdiffz.exe"));

--- a/DemoProject/Assets/Hash's_Things/EditDistributor/Editor/EditDistributorBuilder.cs
+++ b/DemoProject/Assets/Hash's_Things/EditDistributor/Editor/EditDistributorBuilder.cs
@@ -136,7 +136,7 @@ namespace EditDistributor {
                                 {
                                     if (!string.IsNullOrEmpty(DistributionNameOverwriteText))
                                     {
-                                        patcherFolder = Path.Combine(CommunFonctions.GoUpNDirs(CustomfbxPath, 3), DistributionNameOverwriteText, "patcher");
+                                        patcherFolder = Path.Combine(CommunFonctions.GoUpNDirs(CustomfbxPath, 3), DistributionNameOverwriteText, "Patcher");
                                         PatcherScriptDestDir = Path.Combine(CommunFonctions.GoUpNDirs(outputDirectory, 2), "Editor", DistributionNameOverwriteText.Replace(" ", "_") + "_Patcher.cs");
                                     }
                                 }
@@ -174,9 +174,9 @@ namespace EditDistributor {
                     UserEditorWindowName = EditorGUILayout.TextField(new GUIContent("Your Name: ", "Will be used to organize your patchers in the menu bar"), UserEditorWindowName);
                     if (NameOverwriteTickBox)
                     {
-                        if (! string.IsNullOrEmpty(DistributionNameOverwriteText)) EditorWindowPath = "Tools/" + UserEditorWindowName + "/" + DistributionNameOverwriteText + " Patch";
+                        if (! string.IsNullOrEmpty(DistributionNameOverwriteText)) EditorWindowPath = "Tools/" + UserEditorWindowName + "/" + DistributionNameOverwriteText + " Patcher";
                     }
-                    else EditorWindowPath = "Tools/" + UserEditorWindowName + "/" + Path.GetFileNameWithoutExtension(OGfbxPath) + " Patch";
+                    else EditorWindowPath = "Tools/" + UserEditorWindowName + "/" + Path.GetFileNameWithoutExtension(OGfbxPath) + " Patcher";
                     if (string.IsNullOrEmpty(UserEditorWindowName))
                     {
 
@@ -464,7 +464,7 @@ namespace EditDistributor {
             UnityEngine.Debug.Log(EditorWindowPath);
             CommunFonctions.ReplaceStringsInFile(PatcherScriptDestDir, originalStrings, remplacementStrings);
 
-            UnityEngine.Debug.Log("Patcher created");
+            UnityEngine.Debug.Log("Patcher created yippie :D");
             AssetDatabase.Refresh();
         }
 

--- a/DemoProject/Assets/Hash's_Things/EditDistributor/Editor/EditDistributorUpdater.cs
+++ b/DemoProject/Assets/Hash's_Things/EditDistributor/Editor/EditDistributorUpdater.cs
@@ -116,7 +116,7 @@ namespace EditDistributor
                             }
                             else
                             {
-                                patcherToUpdate = Path.Combine(CommunFonctions.GoUpNDirs(CustomfbxPath, 2), "patcher", "Editor", Path.GetFileNameWithoutExtension(CustomfbxPath) + "_Patcher.cs");
+                                patcherToUpdate = Path.Combine(CommunFonctions.GoUpNDirs(CustomfbxPath, 2), "Patcher", "Editor", Path.GetFileNameWithoutExtension(CustomfbxPath) + "_Patcher.cs");
                             }
                         }
                         else
@@ -168,8 +168,8 @@ namespace EditDistributor
                     {
                         DestinationDir = EditorUtility.OpenFolderPanel("Select Folder", "", "");
                     }
-                    EditorGUILayout.LabelField("custom desc source: ", DescriptionDir);
-                    EditorGUILayout.LabelField("custom desc dest: ", DestinationDir);
+                    EditorGUILayout.LabelField("Custom desc source: ", DescriptionDir);
+                    EditorGUILayout.LabelField("Custom desc dest: ", DestinationDir);
 
                     CreatorName = EditorGUILayout.TextField("CreatorName ", CreatorName);
 
@@ -181,7 +181,7 @@ namespace EditDistributor
 
                 }
             }
-            UnityEngine.Debug.Log("patcher to update: " + patcherToUpdate);
+            UnityEngine.Debug.Log("Patcher to update: " + patcherToUpdate);
             UnityEngine.Debug.Log("Does the patcher to update exists" + File.Exists(patcherToUpdate));
 
 
@@ -284,13 +284,13 @@ namespace EditDistributor
             }
             if (debugMessage == 4)
             {
-                CommunFonctions.AddBoldCenteredLabel("patcher updated!");
+                CommunFonctions.AddBoldCenteredLabel("Patcher updated!");
             }
         }
 
         private void Updating()
         {
-            string outputDirectory = Path.Combine(CommunFonctions.GoUpNDirs(CustomfbxPath, 2), "patcher", "data", "DiffFiles");
+            string outputDirectory = Path.Combine(CommunFonctions.GoUpNDirs(CustomfbxPath, 2), "Patcher", "Data", "DiffFiles");
 
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))    hdiffz = Path.Combine(Environment.CurrentDirectory, "Assets", "Hash's_Things", "EditDistributor", "hdiff", "hdiffz", "Windows", "hdiffz.exe");

--- a/DemoProject/Assets/Hash's_Things/EditDistributor/Editor/PatcherTemplate.cs
+++ b/DemoProject/Assets/Hash's_Things/EditDistributor/Editor/PatcherTemplate.cs
@@ -151,7 +151,7 @@ public class PatcherTemplate : EditorWindow
                 {
                     case 0:
                         //please click the button
-                        AddBoldCenteredLabel("Please click the button above to patch your moddel :)");
+                        AddBoldCenteredLabel("Please click the button above to patch your model :)");
                         EditorGUILayout.Space(10);
                         AddBoldCenteredLabel("Please double check that you used " + AvatarVersion);
                         AddBoldCenteredLabel("to import the original avatar in your project");
@@ -168,7 +168,6 @@ public class PatcherTemplate : EditorWindow
                         AddBoldCenteredLabel("/!\\ Something went wrong during the patching of the import file /!\\ ");
                         EditorGUILayout.Space(10);
                         AddBoldCenteredLabel("Please double check that you used " + AvatarVersion + "to import the original avatar in your project");
-                        AddBoldCenteredLabel("to import the original avatar in your project");
                         break;
                     case 6:
                         AddBoldCenteredLabel("FBX patched, get to the prefab folder to enjoy your product");

--- a/DemoProject/Assets/Hash's_Things/EditDistributor/Editor/PatcherTemplate.cs
+++ b/DemoProject/Assets/Hash's_Things/EditDistributor/Editor/PatcherTemplate.cs
@@ -20,6 +20,8 @@ public class PatcherTemplate : EditorWindow
     public static void ShowWindow()
     {
         PatcherTemplate window = GetWindow<PatcherTemplate>(@"NameOfWindow");
+        if (!Debug) window.maxSize = new Vector2(442, 223);
+        if (Debug) window.maxSize = new Vector2(1000, 700);
         window.Show();
     }
 
@@ -63,7 +65,7 @@ public class PatcherTemplate : EditorWindow
             }
             else if (File.Exists(currentCustomfbxPath))
             {
-                AddBoldCenteredLabel("Edited model is already in the folder");
+                AddBoldCenteredLabel("Edited model is already in the folder Enjoy :)");
                 debugMessage = 2;
             }
             else if (!(File.Exists(FBXDiffFile) && File.Exists(MetaDiffFile)))
@@ -150,15 +152,15 @@ public class PatcherTemplate : EditorWindow
                     case 0:
                         break;
                     case 4:
-                        //fbx fail
-                        AddBoldCenteredLabel("Failed patching the FBX!");
+                        //fbx fucked up
+                        AddBoldCenteredLabel("/!\\ Something went wrong during the patching of the FBX /!\\ ");
                         EditorGUILayout.Space(10);
                         AddBoldCenteredLabel("Please double check that you used " + AvatarVersion);
                         AddBoldCenteredLabel("to import the original avatar in your project");
                         break;
                     case 5:
-                        //meta fail
-                        AddBoldCenteredLabel("FBX configuration has been modified!");
+                        //meta fucked up
+                        AddBoldCenteredLabel("/!\\ Something went wrong during the patching of the import file /!\\ ");
                         EditorGUILayout.Space(10);
                         AddBoldCenteredLabel("Please double check that you used " + AvatarVersion);
                         AddBoldCenteredLabel("to import the original avatar in your project");

--- a/DemoProject/Assets/Hash's_Things/EditDistributor/Editor/PatcherTemplate.cs
+++ b/DemoProject/Assets/Hash's_Things/EditDistributor/Editor/PatcherTemplate.cs
@@ -20,8 +20,6 @@ public class PatcherTemplate : EditorWindow
     public static void ShowWindow()
     {
         PatcherTemplate window = GetWindow<PatcherTemplate>(@"NameOfWindow");
-        if (!Debug) window.maxSize = new Vector2(442, 223);
-        if (Debug) window.maxSize = new Vector2(1000, 700);
         window.Show();
     }
 
@@ -65,7 +63,7 @@ public class PatcherTemplate : EditorWindow
             }
             else if (File.Exists(currentCustomfbxPath))
             {
-                AddBoldCenteredLabel("Edited moddel is already in the folder Enjoy :)");
+                AddBoldCenteredLabel("Edited model is already in the folder");
                 debugMessage = 2;
             }
             else if (!(File.Exists(FBXDiffFile) && File.Exists(MetaDiffFile)))
@@ -150,27 +148,23 @@ public class PatcherTemplate : EditorWindow
                 switch (debugMessage)
                 {
                     case 0:
-                        //please click the button
-                        AddBoldCenteredLabel("Please click the button above to patch your moddel :)");
-                        EditorGUILayout.Space(10);
-                        AddBoldCenteredLabel("Please double check that you used " + AvatarVersion);
-                        AddBoldCenteredLabel("to import the original avatar in your project");
                         break;
                     case 4:
-                        //fbx fucked up
-                        AddBoldCenteredLabel("/!\\ Something went wrong during the patching of the FBX /!\\ ");
+                        //fbx fail
+                        AddBoldCenteredLabel("Failed patching the FBX!");
                         EditorGUILayout.Space(10);
                         AddBoldCenteredLabel("Please double check that you used " + AvatarVersion);
                         AddBoldCenteredLabel("to import the original avatar in your project");
                         break;
                     case 5:
-                        //meta fucked up
-                        AddBoldCenteredLabel("/!\\ Something went wrong during the patching of the import file /!\\ ");
+                        //meta fail
+                        AddBoldCenteredLabel("FBX configuration has been modified!");
                         EditorGUILayout.Space(10);
-                        AddBoldCenteredLabel("Please double check that you used " + AvatarVersion + "to import the original avatar in your project");
+                        AddBoldCenteredLabel("Please double check that you used " + AvatarVersion);
+                        AddBoldCenteredLabel("to import the original avatar in your project");
                         break;
                     case 6:
-                        AddBoldCenteredLabel("FBX patched, get to the prefab folder to enjoy your product");
+                        AddBoldCenteredLabel("FBX patched!");
                         break;
                     default:
                         break;
@@ -183,7 +177,7 @@ public class PatcherTemplate : EditorWindow
             {
                 EditorGUILayout.BeginHorizontal();
                 GUILayout.FlexibleSpace();
-                if (GUILayout.Button("this package is using Hash's edit Distributor", EditorStyles.linkLabel))
+                if (GUILayout.Button("This package is using Hash's Edit Distributor", EditorStyles.linkLabel))
                 {
                     Application.OpenURL("https://github.com/HashEdits/Face-Tracking-Patcher");
                 }
@@ -260,7 +254,7 @@ public class PatcherTemplate : EditorWindow
                 // Write the input string to the file
                 File.WriteAllText(filePath, inputString);
 
-                if (Debug) UnityEngine.Debug.Log("something went wrong, please get in contact and provide: " + filePath + "/" + fileName);
+                if (Debug) UnityEngine.Debug.Log("Something went wrong, please get in contact and provide: " + filePath + "/" + fileName);
                 return true;
             }
             catch (Exception e)

--- a/DemoProject/Assets/Hash's_Things/EditDistributor/Editor/PatcherTemplate.cs
+++ b/DemoProject/Assets/Hash's_Things/EditDistributor/Editor/PatcherTemplate.cs
@@ -150,6 +150,11 @@ public class PatcherTemplate : EditorWindow
                 switch (debugMessage)
                 {
                     case 0:
+                        //please click the button
+                        AddBoldCenteredLabel("Please click the button above to patch your moddel :)");
+                        EditorGUILayout.Space(10);
+                        AddBoldCenteredLabel("Please double check that you used " + AvatarVersion);
+                        AddBoldCenteredLabel("to import the original avatar in your project");
                         break;
                     case 4:
                         //fbx fucked up
@@ -162,11 +167,11 @@ public class PatcherTemplate : EditorWindow
                         //meta fucked up
                         AddBoldCenteredLabel("/!\\ Something went wrong during the patching of the import file /!\\ ");
                         EditorGUILayout.Space(10);
-                        AddBoldCenteredLabel("Please double check that you used " + AvatarVersion);
+                        AddBoldCenteredLabel("Please double check that you used " + AvatarVersion + "to import the original avatar in your project");
                         AddBoldCenteredLabel("to import the original avatar in your project");
                         break;
                     case 6:
-                        AddBoldCenteredLabel("FBX patched!");
+                        AddBoldCenteredLabel("FBX patched, get to the prefab folder to enjoy your product");
                         break;
                     default:
                         break;


### PR DESCRIPTION
- Formatting is changed to keep the code constant, spelling mistakes, and more visually pleasing. 
- Window size limit removed for long avatar text versions getting clipped on the avatar patch window.
- Fixed multi FBX building failing with multiple FBX in the same folder.

